### PR TITLE
use assertthat to get error for duplicate object ids

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Imports: 
+    assertthat,
     dplyr,
     here,
     httr,

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -76,8 +76,10 @@ input_data <-
 
 Check whether `object_id` is unique (value should be `0`)
 
-```{r}
-anyDuplicated(input_data$objectid)
+```{r check for duplicate object ids}
+assertthat::assert_that(anyDuplicated(input_data$objectid) == 0,
+                        msg = "OBJECTID should never be duplicated")
+
 ```
 
 Remove all rows for `Domein` = `Werken`


### PR DESCRIPTION
Currently there was a check that needs to be caught by a human, I think a failure mode via assertthat is safer