### PR TITLE
Remove objects that have `test`/`TEST` in a comment field

### DIFF
--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -255,10 +255,12 @@ input_data <-
 test_objects <-
   filter(
     input_data,
-    stringr::str_detect(opmerkingen, "\\btest\\b") |
-      stringr::str_detect(opmerkingen, "\\bTEST\\b") |
-      stringr::str_detect(opmerkingen_admin, "\\btest\\b") |
-      stringr::str_detect(opmerkingen_admin, "\\bTEST\\b")
+    stringr::str_detect(opmerkingen,
+                        stringr::regex("\\btest\\b",
+                                       ignore_case = TRUE)) |
+      stringr::str_detect(opmerkingen_admin,
+                          stringr::regex("\\btest\\b",
+                                         ignore_case = TRUE))
   ) %>%
   pull(objectid)
 # removing these records from the input dataset

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -245,6 +245,27 @@ input_data <-
     )
   )
 ```
+## Drop test records based on "opmerkingen" and "opmerkingen_admin"
+
+```{r drop test records}
+
+# getting the records that have the word test in their comment fields, using
+# word boundaries to avoid matching comments that just have test in the
+# streetname
+test_objects <-
+  filter(
+    input_data,
+    stringr::str_detect(opmerkingen, "\\btest\\b") |
+      stringr::str_detect(opmerkingen, "\\bTEST\\b") |
+      stringr::str_detect(opmerkingen_admin, "\\btest\\b") |
+      stringr::str_detect(opmerkingen_admin, "\\bTEST\\b")
+  ) %>%
+  pull(objectid)
+# removing these records from the input dataset
+input_data <- input_data %>% filter(!objectid %in% test_objects)
+
+```
+
 
 ## Extract information from "materiaal_vast"
 

--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -213,3 +213,11 @@ testthat::test_that("taxonRank is always filled in and one of the list", {
     all(dwc_occurrence$taxonRank %in% taxon_ranks)
   )
 })
+
+testthat::test_that("known test objects are removed from output", {
+  testthat::expect_identical(
+    nrow(filter(dwc_occurrence, occurrenceID %in%
+      c("449283", "449284", "449285", "449317", "450596"))),
+    0L
+  )
+})

--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -217,7 +217,19 @@ testthat::test_that("taxonRank is always filled in and one of the list", {
 testthat::test_that("known test objects are removed from output", {
   testthat::expect_identical(
     nrow(filter(dwc_occurrence, occurrenceID %in%
-      c("449283", "449284", "449285", "449317", "450596"))),
+                  c(
+                    "432883",
+                    "432884",
+                    "432887",
+                    "432896",
+                    "437303",
+                    "449283",
+                    "449284",
+                    "449285",
+                    "449317",
+                    "450596",
+                    "596279"
+                  ))),
     0L
   )
 })


### PR DESCRIPTION
We sent some records to RATO to check, some were errors, some were test records (events: dossier):

> Sommige dossiers betroffen testdata: de testdata werden opgeschoond, maar enkele moeten blijven staan om testen mogelijk te maken In opmerking staat dat het een ‘TEST’ betreft. 

We could remove these in the fetch step, or in the mapping, by filtering on the string `test`/`TEST` in both `Opmerkingen` and `Opmerkingen_admin`