### PR TITLE
Add tests missing data

### DIFF
--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -9,6 +9,11 @@ dwc_occurrence <-
   readr::read_csv(occs_path, guess_max = 10000, show_col_types = FALSE)
 
 # tests
+
+testthat::test_that("The occurrence output exists", {
+  testthat::expect_true(file.exists(occs_path))
+})
+
 testthat::test_that("Right columns in right order", {
   columns <- c(
     "type",

--- a/tests/test_dwc_occurrence.R
+++ b/tests/test_dwc_occurrence.R
@@ -238,3 +238,13 @@ testthat::test_that("known test objects are removed from output", {
     0L
   )
 })
+
+testthat::test_that(
+  "There is at least one record for every year since the beginning of the data",{
+    testthat::expect_equal(
+      unique(lubridate::year(dwc_occurrence$eventDate)),
+      seq(2021, as.double(format(Sys.Date(), "%Y"))),
+      tolerance = 0 # so it will allow comparing doubles and integers
+    )
+  })
+


### PR DESCRIPTION
A while ago, all observations that weren't from 2023 were removed from the raw data. With this PR I implement a test that will fail if something like this happens. 

I also added a test that checks if `occurrence.csv` exists. It always should, since if the mapping fails, the old one will still be there, but I feel better with the little test in place. 
