### PR TITLE
Archive raw data from 2021 and 2022, read from archive instead of connection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,8 +32,10 @@ Imports:
     purrr,
     readr,
     rgbif,
+    safer,
     sf,
     stringr,
     testthat,
     tidylog,
-    tidyr
+    tidyr,
+    withr

--- a/src/create_archive_data.R
+++ b/src/create_archive_data.R
@@ -1,0 +1,24 @@
+# Create archive files to read from until data from 2021 and 2022 is restored
+
+# In November 2023, RATO removed data from 2021 and 2022 from the source. The
+# intention exists to restore this data by March 2024. In the meantime a local
+# archive of this raw data was stored in the repo and is used instead.
+
+tables_to_archive <-
+  readr::read_csv("data/raw/rato_data.csv") %>%
+  mutate(bewerkt_year = lubridate::year(Laatst_Bewerkt_Datum)) %>%
+  filter(bewerkt_year < 2023) %>%
+  group_by(bewerkt_year) %>%
+  nest() %>%
+  pull(data)
+
+for (table in tables_to_archive) {
+  readr::write_csv(table, here::here(
+    "data",
+    "raw",
+    glue::glue(
+      "{dataset_year}_archive_rato_data.csv",
+      dataset_year = unique(lubridate::year(table$Laatst_Bewerkt_Datum))
+    )
+  ))
+}

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -59,6 +59,22 @@ Rename `raw_data` to `input_data` so we can keep original values
 input_data <- raw_data
 ```
 
+## Read old archive data 
+In November 2023, RATO removed data from 2021 and 2022 from the source. The 
+intention exists to restore this data by March 2024. In the meantime a local 
+archive of this raw data was stored in the repo and is used instead.
+```{r read archive data}
+input_data <- list.files(
+  here::here("data","raw"),
+  pattern = "20[0-9]{2}_archive_rato_data",
+  full.names = TRUE
+) %>% 
+  purrr::map(readr::read_csv, show_col_types = FALSE) %>% 
+  purrr::list_rbind() %>% 
+  dplyr::bind_rows(input_data)
+```
+
+
 # Process source data
 
 ## Tidy data

--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -44,13 +44,31 @@ library(sf)             # To convert coordinate systems
 ```
 
 # Read source data
+Since late 2023 the raw data is stored encrypted based on a private key. If the decryption key is not in the system environment, ask for the key.
+
+```{r}
+if(Sys.getenv("encryption_key") == "" & interactive()){
+  Sys.setenv(encryption_key = 
+               askpass::askpass(prompt = "Please enter encryption key")
+  )
+}
+```
 
 Create a data frame `input_data` from the source data:
 
 ```{r read raw data}
-raw_data <- readr::read_csv(
-  here::here("data", "raw", "rato_data.csv")
-) 
+withr::with_file(
+  "rato_data_decrypted.csv",
+  {
+    safer::decrypt_file(
+      here::here("data", "raw", "rato_data"),
+      key = Sys.getenv("encryption_key"),
+      outfile = "rato_data_decrypted.csv"
+    )
+    
+    raw_data <- readr::read_csv("rato_data_decrypted.csv")
+  }
+)
 ```
 
 Rename `raw_data` to `input_data` so we can keep original values


### PR DESCRIPTION
Late 2023 RATO removed all records from 2021 and 2022 from the raw data in an attempt to speed up database operations. This attempt was unsuccessful, and they will restore these records by March 2024. In the meantime we'd ideally continue updating the GBIF dataset, however, we do not want to remove these 6400+ records from the publication. 

A possible stopgap is to archive the raw data from 2021 and 2022 as separate files, and to read from those in addition to the fetched raw data from the WFS/ArcGIS Enterprise Server. 