### PR TITLE
Place fetch and mapping scripts in same step

### DIFF
--- a/.github/workflows/fetch-data_mapping.yaml
+++ b/.github/workflows/fetch-data_mapping.yaml
@@ -56,15 +56,11 @@ jobs:
           cache: true
           needs: check
 
-      - name: Fetch data
+      - name: Fetch data and map to DwC
         env:
           ratopwd: ${{ secrets.RATOPWD }}
         run: |
           source("src/run_fetch_data.R")
-        shell: Rscript {0}
-
-      - name: Mapping to DwC
-        run: |
           source("src/run_dwc_mapping.R")
         shell: Rscript {0}
 


### PR DESCRIPTION
It seems the mapping script does not have access to the raw_data object from the fetching script. Maybe placing them in the same step of the job will fix this. 
