### PR TITLE
remove trailing whitespace so we can use a space to detect multiple v…

### DIFF
--- a/src/dwc_mapping.Rmd
+++ b/src/dwc_mapping.Rmd
@@ -119,6 +119,13 @@ First, we need to clean `Haard vastgesteld = 0; Waarneming onzeker = 1;`. This s
 input_data %<>% mutate(waarneming = recode(waarneming,
   "Haard vastgesteld = 0; Waarneming onzeker = 1;" = "Waarneming onzeker = 1;"))
 ```
+Remove trailing whitespace from waarneming, so we can use `; ` as a way to detect multiple values for this field
+
+```{r remove trailing whitespace from waarneming}
+input_data <- 
+  input_data %>% 
+  mutate(waarneming = stringr::str_trim(waarneming))
+```
 
 Remove occurrences containing multiple type - value pairs information in column `waarneming` (patch until [#23](https://github.com/riparias/rato-occurrences/issues/23) is solved):
 


### PR DESCRIPTION
fixes #152 

We are using a separator plus a space to detect multiple values, when a space was added to the end of records, this triggered our detection and removed loads of records. By trimming trailing whitespace, we avoid tripping this filter. 