### PR TITLE
testthat is not loaded by default, fix with usethis

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,3 +44,4 @@ Imports:
 Depends: 
     R (>= 2.10)
 LazyData: true
+Config/testthat/edition: 3

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(rato.occurrences)
+
+test_check("rato.occurrences")


### PR DESCRIPTION
`usethis::use_testthat()` might allow us to get rid of all the `testthat::test_that()` in tests