### PR TITLE
Add call to devtools to install package before testing

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -53,5 +53,6 @@ jobs:
 
       - name: Run tests
         run: |
+          devtools::install(quick = TRUE)
           source("tests/test_dwc_occurrence.R")
         shell: Rscript {0}


### PR DESCRIPTION
Since placing the list of expected species in a data object, the package needs to be installed (and loaded) before tests can run. Before the tests were completely standalone. 

I did this (#242) so I only need to maintain this reference list in a single spot and as a step towards an easier to maintain and more dependable testing workflow. 

In this PR I'm explicitly calling `devtools::install()` but skipping things like vignettes and documentation for speed. 