### PR TITLE
Use Posit package manager repo to get binaries

### DIFF
--- a/.github/workflows/fetch-data_mapping.yaml
+++ b/.github/workflows/fetch-data_mapping.yaml
@@ -39,6 +39,9 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
+          
+      - name: Set CRAN repo to Posit Public Package Manager
+        run: echo "options(repos = c(CRAN = 'https://packagemanager.posit.co/cran/latest'))" >> ~/.Rprofile
 
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v2

--- a/.github/workflows/fetch-data_mapping.yaml
+++ b/.github/workflows/fetch-data_mapping.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-latest,   r: 'release'}
+          - {os: ubuntu-22.04,   r: '4.4'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}

--- a/.github/workflows/fetch-data_mapping.yaml
+++ b/.github/workflows/fetch-data_mapping.yaml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: ubuntu-22.04,   r: '4.4'}
+          - {os: ubuntu-24.04,   r: '4.4'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to configure the R environment for improved package management.

**Workflow configuration updates:**

* [`.github/workflows/fetch-data_mapping.yaml`](diffhunk://#diff-26cadd0076ccb086e11e8c3626da229b09d906c6cfe25659528d68cba6b35ad1R43-R45): Added a step to set the CRAN repository to the Posit Public Package Manager by appending the configuration to the `~/.Rprofile`. This ensures consistent and reliable access to R packages during the workflow execution.