### PR TITLE
Switch data fetch workflow to use macos runner

### DIFF
--- a/.github/workflows/fetch-data_mapping.yaml
+++ b/.github/workflows/fetch-data_mapping.yaml
@@ -43,13 +43,6 @@ jobs:
       - name: Setup pandoc
         uses: r-lib/actions/setup-pandoc@v2
 
-      - name: Install linux libraries
-        run: |
-          sudo apt install libsodium-dev
-          sudo apt-get install libcurl4-openssl-dev
-          sudo apt-get install libgdal-dev libproj-dev
-          sudo apt install libudunits2-dev
-
       - name: Install R packages
         uses: r-lib/actions/setup-r-dependencies@v2
         with:


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for the `fetch-data_mapping.yaml` file to improve compatibility and streamline the setup process. The key changes include switching the operating system for the job matrix and removing unnecessary installation steps for Linux libraries.

Workflow configuration updates:

* Changed the operating system in the job matrix from `ubuntu-latest` to `macos-latest` to align with the new environment requirements. (`.github/workflows/fetch-data_mapping.yaml`, [.github/workflows/fetch-data_mapping.yamlL24-R24](diffhunk://#diff-26cadd0076ccb086e11e8c3626da229b09d906c6cfe25659528d68cba6b35ad1L24-R24))

Simplification of setup steps:

* Removed the installation of Linux-specific libraries (`libsodium-dev`, `libcurl4-openssl-dev`, `libgdal-dev`, `libproj-dev`, and `libudunits2-dev`) as they are no longer needed in the updated workflow. (`.github/workflows/fetch-data_mapping.yaml`, [.github/workflows/fetch-data_mapping.yamlL46-L52](diffhunk://#diff-26cadd0076ccb086e11e8c3626da229b09d906c6cfe25659528d68cba6b35ad1L46-L52))