### PR TITLE
Increase bucket size for throttling API requests

### DIFF
--- a/.github/workflows/fetch-data_mapping.yaml
+++ b/.github/workflows/fetch-data_mapping.yaml
@@ -26,6 +26,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       RSPM: ${{ matrix.config.rspm }}
       GITHUB_TOKEN: ${{ secrets.WORKFLOWS }}
+      RATO_API_CAPACITY: 1500
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
This pull request makes a small change to the workflow configuration by adding a new environment variable to control API capacity.

* Added the `RATO_API_CAPACITY` environment variable with a value of `1500` to the `jobs` section of `.github/workflows/fetch-data_mapping.yaml`.